### PR TITLE
Throwing assertion error when util class is instantiating and it can't be inherited

### DIFF
--- a/src/main/java/com/jpomykala/springhoc/utils/RequestUtils.java
+++ b/src/main/java/com/jpomykala/springhoc/utils/RequestUtils.java
@@ -10,6 +10,7 @@ public final class RequestUtils {
 
   private RequestUtils() {
     //hidden constructor
+    throw new AssertionError("Util class not available for instantiation");
   }
 
   public static String getClientIP(HttpServletRequest request) {


### PR DESCRIPTION
Sometimes util classes give impression that these can be inherited and open for instantiation. Here, it throws assertion error when this util class is instantiated. 